### PR TITLE
Handle corner case if no modules are loaded

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ fs.existsSync = fs.existsSync || path.existsSync;
 var main_paths = require.main && require.main.paths || [];
 
 module.exports = function() {
-    var paths = Object.keys(require.cache);
+    var paths = Object.keys(require.cache || []);
 
     // module information
     var infos = {};


### PR DESCRIPTION
Admittedly this seems to be a rare corner case, but it happens if you're browserify-ing your sources to package them into a single huge js file. In that case no external modules will be loaded and `require.cache` will not be set, causing the code to throw an exception.
